### PR TITLE
fixes and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### v1.1.2
 * Added `varargs` to `storage.modifier.lpc`
 * Fixed `.` and `->` access to accessing class members as `keyword.operator.access.lpc`
-* Added `_` separator for integer literals in `constant.numeric.lpc`
+* Added `_` separator for integer and float literals in `constant.numeric.lpc`
 
 ### v1.1.1
 * Removed triangular brackets that were causing issues. `<` and `>` are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### v1.1.2
+* Added `varargs` to `storage.modifier.lpc`
+* Fixed `.` and `->` access to accessing class members as `keyword.operator.access.lpc`
+* Added `_` separator for integer literals in `constant.numeric.lpc`
+
 ### v1.1.1
 * Removed triangular brackets that were causing issues. `<` and `>` are not
   used in FluffOS as brackets. If needed for other drivers, can re-evaluate

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Basic syntax highlighting for LPC
 ### v1.1.2
 * Added `varargs` to `storage.modifier.lpc`
 * Fixed `.` and `->` access to accessing class members as `keyword.operator.access.lpc`
-* Added `_` separator for integer literals in `constant.numeric.lpc`
+* Added `_` separator for integer and float literals in `constant.numeric.lpc`
 ### v1.1.1
 * Removed triangular brackets that were causing issues. `<` and `>` are not
   used in FluffOS as brackets. If needed for other drivers, can re-evaluate
@@ -41,3 +41,4 @@ Basic syntax highlighting for LPC
 ## Contribute
 
 If you'd like to contribute please check out our project page: [GwennKoi/vscode-lpc-lang](http://github.com/GwennKoi/vscode-lpc-lang)
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Basic syntax highlighting for LPC
 
 ## Release Notes
 
+### v1.1.2
+* Added `varargs` to `storage.modifier.lpc`
+* Fixed `.` and `->` access to accessing class members as `keyword.operator.access.lpc`
+* Added `_` separator for integer literals in `constant.numeric.lpc`
 ### v1.1.1
 * Removed triangular brackets that were causing issues. `<` and `>` are not
   used in FluffOS as brackets. If needed for other drivers, can re-evaluate

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-lpc-lang",
 	"displayName": "LPC Language",
 	"description": "LPmud C Language syntax highlighting for the FLUFFOS branch of LPmud drivers.",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"publisher": "undeadfish",
 	"engines": {
 		"vscode": "^1.75.0"

--- a/samples/sample.c
+++ b/samples/sample.c
@@ -1,0 +1,50 @@
+class Foo {
+    int some_int;
+    float some_float;
+    mapping some_mapping;
+    string some_string;
+    string *some_ints ;
+    float *some_floats ;
+    mapping *some_mappings ;
+    string *some_strings ;
+}
+
+nosave int a_global_int = 10;
+
+varargs nomask void some_function(int a, float b, mapping c, string d) {
+    class Foo foo ;
+    class Foo foo2 ;
+    int another_number ;
+    int hex_number ;
+    float another_float ;
+    object ob ;
+
+    foo = new(class Foo);
+    foo->some_int = a;
+    foo->some_float = b;
+    foo->some_mapping = c;
+    foo->some_string = d;
+    foo->some_ints = ({ 1, 2, 3 });
+    foo->some_floats = ({ 1.0, 2.0, 3.0 });
+    foo->some_mappings = ({ ([ "a" : 1 ]), ([ "b" : 2 ]), ([ "c" : 3 ]) });
+    foo->some_strings = ({ "a", "b", "c" });
+
+    foo2 = new(class Foo);
+    foo2.some_int = a;
+    foo2.some_float = b;
+    foo2.some_mapping = c;
+    foo2.some_string = d;
+    foo2.some_ints = ({ 1, 2, 3 });
+    foo2.some_floats = ({ 1.0, 2.0, 3.0 });
+    foo2.some_mappings = ({ ([ "a" : 1 ]), ([ "b" : 2 ]), ([ "c" : 3 ]) });
+    foo2.some_strings = ({ "a", "b", "c" });
+
+    another_number = 100_100
+    another_float = 100_100.100_100
+    hex_number = 0x123;
+
+    ob->remove() ;
+    this_object()->remove() ;
+
+    return;
+}

--- a/samples/sample.c
+++ b/samples/sample.c
@@ -18,6 +18,7 @@ varargs nomask void some_function(int a, float b, mapping c, string d) {
     int hex_number ;
     float another_float ;
     object ob ;
+    string multi_line_string, *multi_line_array ;
 
     foo = new(class Foo);
     foo->some_int = a;
@@ -46,5 +47,14 @@ varargs nomask void some_function(int a, float b, mapping c, string d) {
     ob->remove() ;
     this_object()->remove() ;
 
+    multi_line_string = @text
+This is a multiline string.
+We stan a good multiline string.
+text;
+
+    multi_line_array = @@lines
+This is a multiline array.
+Heckin' yeah we love a multiline array.
+lines ;
     return;
 }

--- a/syntaxes/lpc.tmLanguage
+++ b/syntaxes/lpc.tmLanguage
@@ -98,7 +98,7 @@
 				<key>comment</key>
 				<string>Modifiers</string>
 				<key>match</key>
-				<string>\b(public|private|protected|nosave|nomask)\b</string>
+				<string>\b(public|private|protected|nosave|nomask|varargs)\b</string>
 				<key>name</key>
 				<string>storage.modifier.lpc</string>
 			</dict>
@@ -106,7 +106,7 @@
 				<key>comment</key>
 				<string>Numeric values</string>
 				<key>match</key>
-				<string>(?:\b|(?&lt;!\.)(?=\.))((0(x|X)[0-9a-fA-F]*)|(0(b|B)[01]+)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)\b</string>
+				<string>(?:\b|(?&lt;!\.)(?=\.))((0(x|X)[0-9a-fA-F]*)|(([0-9_]+\.?[0-9_]*)|(\.[0-9_]+))((-)?[0-9_]+)?)\b</string>
 				<key>name</key>
 				<string>constant.numeric.lpc</string>
 			</dict>
@@ -158,14 +158,6 @@
 						<string>#string_placeholder</string>
 					</dict>
 				</array>
-			</dict>
-			<dict>
-				<key>comment</key>
-				<string>Multiline string literal</string>
-				<key>match</key>
-				<string>(@{1,2}(\w*))\n((.|\n)*?)\n(###\s*)?(\2)\b</string>
-				<key>name</key>
-				<string>string.quoted.other.lpc</string>
 			</dict>
 			<dict>
 				<key>begin</key>
@@ -999,13 +991,13 @@
 			<key>dot_access</key>
 			<dict>
 				<key>match</key>
-				<string>[a-zA-Z0-9_]\s*(\.|-&gt;)\s*[a-zA-Z0-9_]</string>
+				<string>\b[a-zA-Z_][a-zA-Z0-9_]*\s*(\.|-&gt;)\s*[a-zA-Z_][a-zA-Z0-9_]*\b</string>
 				<key>captures</key>
 				<dict>
 					<key>1</key>
 					<dict>
 						<key>name</key>
-						<string>punctuation.separator.dot-access.lpc</string>
+						<string>keyword.operator.access.lpc</string>
 					</dict>
 				</dict>
 			</dict>


### PR DESCRIPTION
### v1.1.2
* Added `varargs` to `storage.modifier.lpc`
* Fixed `.` and `->` access to accessing class members as `keyword.operator.access.lpc`
* Added `_` separator for integer and float literals in `constant.numeric.lpc`