### PR TITLE
Change TM scope for primitive types to be consistent with other typed languages

### DIFF
--- a/syntaxes/lpc.tmLanguage
+++ b/syntaxes/lpc.tmLanguage
@@ -92,7 +92,7 @@
 				<key>match</key>
 				<string>\b(float|int|void|object|class|mapping|string|mixed|function|ref)\b</string>
 				<key>name</key>
-				<string>storage.type.lpc</string>
+				<string>support.type.primitive.lpc</string>
 			</dict>
 			<dict>
 				<key>comment</key>


### PR DESCRIPTION
Other typed languages use the `support.type` scope instead of `storage.type` for primitive type tokens. I am proposing this change so that LPC is consistent with other languages in how primitive types are colored.