### PR TITLE
Only match single quoted strings on the same line

### DIFF
--- a/syntaxes/lpc.tmLanguage
+++ b/syntaxes/lpc.tmLanguage
@@ -160,26 +160,8 @@
 				</array>
 			</dict>
 			<dict>
-				<key>begin</key>
-				<string>'</string>
-				<key>beginCaptures</key>
-				<dict>
-					<key>0</key>
-					<dict>
-						<key>name</key>
-						<string>punctuation.definition.string.begin.lpc</string>
-					</dict>
-				</dict>
-				<key>end</key>
-				<string>'</string>
-				<key>endCaptures</key>
-				<dict>
-					<key>0</key>
-					<dict>
-						<key>name</key>
-						<string>punctuation.definition.string.end.lpc</string>
-					</dict>
-				</dict>
+				<key>match</key>
+				<string>'[^']*'</string>                
 				<key>name</key>
 				<string>string.quoted.single.lpc</string>
 				<key>patterns</key>


### PR DESCRIPTION
Per a [conversation on Discord](https://discord.com/channels/824777367427612692/824777367938531391/1232442068085899425)

The current match type allows single quoted strings to span multiple lines. This causes a problem in LDMud which allows lambda that start with a single quote, example:
```funcall(symbol_function('transfer), a,b)```

Although this syntax technically isn't for LDMud, both can be accomidated by changing the `string.quoted.single.lpc` scope to only match on a single line as suggested by @gesslar [here](https://discord.com/channels/824777367427612692/824777367938531391/1232444838838931507)