### PR TITLE
call_out() snippet used call_other() function

### DIFF
--- a/snippets/lpc-calls.json
+++ b/snippets/lpc-calls.json
@@ -5,7 +5,7 @@
     },
     "call_out": {
         "prefix": "call_out",
-        "body": "call_other(${1:string|function fun},${2:float|int delay}${3:,mixed arg})"
+        "body": "call_out(${1:string|function fun},${2:float|int delay}${3:,mixed arg})"
     },
     "call_out_walltime" : {
         "prefix": "call_out_walltime",


### PR DESCRIPTION
Fixes a typo I made when entering in all of the code snippets.

Resolves #33 